### PR TITLE
universal figtree bash script

### DIFF
--- a/release/Linux/scripts/figtree
+++ b/release/Linux/scripts/figtree
@@ -1,4 +1,4 @@
 #!/bin/sh
-FIGTREEPATH=`realpath $0 | sed 's/figtree$/\.\.\//'`
-java -Xms64m -Xmx512m -jar ${FIGTREEPATH}lib/figtree.jar "$@"
+FIGTREEPATH=`realpath $0 | sed 's/figtree$/\.\.\/\.\.\/\.\.\//'`
+java -Xms64m -Xmx512m -jar ${FIGTREEPATH}dist/figtree.jar "$@"
 


### PR DESCRIPTION
To have `figtree` in your `$PATH` you included a bash script that executes the `jar` file. Since there is no absolute path, it will not find `figtree.jar`. To avoid that every user needs to edit the script and write the absolute path I allowed myself to find the location of the bash script within itself.
The relative paths from the bash script to `figtree.jar` are different in the cloned repository and the release. The script should be like this to work within a release:
```
#!/bin/sh
FIGTREEPATH=`realpath $0 | sed 's/figtree$/\.\.\//'`
java -Xms64m -Xmx512m -jar ${FIGTREEPATH}lib/figtree.jar "$@"
```