### PR TITLE
Improve script's flexibility wrt location

### DIFF
--- a/release/Linux/scripts/figtree
+++ b/release/Linux/scripts/figtree
@@ -1,4 +1,2 @@
-#!/bin/sh
-
-java -Xms64m -Xmx512m -jar lib/figtree.jar "$@"
-
+#!/usr/bin/env bash
+java -Xms64m -Xmx512m -jar "$(echo $0 | rev | cut -d'/' -f3- | rev)/lib/figtree.jar" "$@"


### PR DESCRIPTION
As it was before, the script couldn't find the JAR file unless you ran the script in a folder containing the ``bin`` and ``lib`` directories. Now, as long as they're next to each other, it can find it regardless of where you call it (so you can add the ``figtree`` script to a directory in your ``PATH``)