### PR TITLE
fix crash when setting font size to 72

### DIFF
--- a/src/figtree/treeviewer/painters/LabelPainterController.java
+++ b/src/figtree/treeviewer/painters/LabelPainterController.java
@@ -152,7 +152,7 @@ public class LabelPainterController extends AbstractController {
         });
 
         Font font = labelPainter.getFont();
-        fontSizeSpinner = new JSpinner(new SpinnerNumberModel(font.getSize(), 0.01, 48, 1));
+        fontSizeSpinner = new JSpinner(new SpinnerNumberModel(font.getSize(), 0.01, 72, 1));
 
         fontSizeSpinner.addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent changeEvent) {

--- a/src/figtree/treeviewer/painters/ScaleBarPainterController.java
+++ b/src/figtree/treeviewer/painters/ScaleBarPainterController.java
@@ -108,7 +108,7 @@ public class ScaleBarPainterController extends AbstractController {
         scaleRangeText.setEnabled(false);
 
         Font font = scaleBarPainter.getFont();
-        fontSizeSpinner = new JSpinner(new SpinnerNumberModel(font.getSize(), 0.01, 48, 1));
+        fontSizeSpinner = new JSpinner(new SpinnerNumberModel(font.getSize(), 0.01, 72, 1));
 
         final JLabel label2 = optionsPanel.addComponentWithLabel("Font Size:", fontSizeSpinner);
 


### PR DESCRIPTION
This small change fixes an issue where after setting the font sizes to 72 under `Edit -> Preferences -> Fonts` the application crashes on restart with:

```
Exception in thread "main" java.lang.IllegalArgumentException: (minimum <= value <= maximum) is false
    at java.desktop/javax.swing.SpinnerNumberModel.<init>(SpinnerNumberModel.java:139)
    at java.desktop/javax.swing.SpinnerNumberModel.<init>(SpinnerNumberModel.java:178)
    at figtree.treeviewer.painters.LabelPainterController.<init>(Unknown Source)
    at figtree.application.FigTreePanel.<init>(Unknown Source)
    at figtree.application.FigTreeFrame.<init>(Unknown Source)
    at figtree.application.FigTreeApplication$3.createDocumentFrame(Unknown Source)
    at jam.framework.MultiDocApplication.createDocumentFrame(Unknown Source)
    at jam.framework.MultiDocApplication.doNew(Unknown Source)
    at figtree.application.FigTreeApplication.main(Unknown Source)
```