### PR TITLE
adding Bare Percent label format option for issue #205

### DIFF
--- a/src/figtree/treeviewer/painters/LabelPainterController.java
+++ b/src/figtree/treeviewer/painters/LabelPainterController.java
@@ -21,6 +21,7 @@
 package figtree.treeviewer.painters;
 
 import figtree.ui.PercentFormat;
+import figtree.ui.BarePercentFormat;
 import figtree.ui.RomanFormat;
 import jam.controlpalettes.AbstractController;
 import jam.controlpalettes.ControllerListener;
@@ -173,7 +174,7 @@ public class LabelPainterController extends AbstractController {
         NumberFormat format = labelPainter.getNumberFormat();
         int digits = format.getMaximumFractionDigits();
 
-        numericalFormatCombo = new JComboBox(new String[] { "Decimal", "Scientific", "Percent", "Roman"});
+        numericalFormatCombo = new JComboBox(new String[] { "Decimal", "Scientific", "Percent", "Bare Percent", "Roman"});
         numericalFormatCombo.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent event) {
                 String formatType = (String) numericalFormatCombo.getSelectedItem();
@@ -185,6 +186,8 @@ public class LabelPainterController extends AbstractController {
                     format = new DecimalFormat(SCIENTIFIC_NUMBER_FORMATTING);
                 } else if (formatType.equals("Percent")) {
                     format = new PercentFormat();
+                } else if (formatType.equals("Bare Percent")) {
+                    format = new BarePercentFormat();
                 } else if (formatType.equals("Roman")) {
                     format = new RomanFormat();
                 }

--- a/src/figtree/treeviewer/painters/LegendPainterController.java
+++ b/src/figtree/treeviewer/painters/LegendPainterController.java
@@ -25,6 +25,7 @@ import figtree.treeviewer.ControllerOptionsPanel;
 import figtree.treeviewer.TreeViewer;
 import figtree.treeviewer.decorators.ColourDecorator;
 import figtree.ui.PercentFormat;
+import figtree.ui.BarePercentFormat;
 import figtree.ui.RomanFormat;
 import jam.controlpalettes.AbstractController;
 import jam.controlpalettes.ControllerListener;
@@ -137,7 +138,7 @@ public class LegendPainterController extends AbstractController {
         NumberFormat format = legendPainter.getNumberFormat();
         int digits = format.getMaximumFractionDigits();
 
-        numericalFormatCombo = new JComboBox(new String[] { "Decimal", "Scientific", "Percent", "Roman"});
+        numericalFormatCombo = new JComboBox(new String[] { "Decimal", "Scientific", "Percent", "Bare Percent", "Roman"});
         numericalFormatCombo.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent event) {
                 String formatType = (String) numericalFormatCombo.getSelectedItem();
@@ -149,6 +150,8 @@ public class LegendPainterController extends AbstractController {
                     format = new DecimalFormat(SCIENTIFIC_NUMBER_FORMATTING);
                 } else if (formatType.equals("Percent")) {
                     format = new PercentFormat();
+                } else if (formatType.equals("Bare Percent")) {
+                    format = new BarePercentFormat();
                 } else if (formatType.equals("Roman")) {
                     format = new RomanFormat();
                 }

--- a/src/figtree/ui/BarePercentFormat.java
+++ b/src/figtree/ui/BarePercentFormat.java
@@ -1,0 +1,184 @@
+/*
+ * BarePercentFormat.java
+ *
+ * Copyright (C) 2006-2014 Andrew Rambaut
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package figtree.ui;
+
+import java.text.*;
+
+/**
+ * This NumberFormat converts numbers to and from percent notation.
+ * Once an instance has been created, the format and parse methods may be used
+ * as defined in java.text.NumberFormat.
+ *
+ * @version $Id$
+ *
+ * $HeadURL$
+ *
+ * $LastChangedBy$
+ * $LastChangedDate$
+ * $LastChangedRevision$
+ */
+
+public class BarePercentFormat extends NumberFormat
+{
+    private final NumberFormat nf;
+
+    public BarePercentFormat() {
+        this.nf = new DecimalFormat();
+    }
+
+
+    /**
+     * Returns the maximum number of digits allowed in the fraction portion of a
+     * number.
+     *
+     * @see #setMaximumFractionDigits
+     */
+    @Override
+    public int getMaximumFractionDigits() {
+        return nf.getMaximumFractionDigits();
+    }
+
+    /**
+     * Returns the maximum number of digits allowed in the integer portion of a
+     * number.
+     *
+     * @see #setMaximumIntegerDigits
+     */
+    @Override
+    public int getMaximumIntegerDigits() {
+        return nf.getMaximumIntegerDigits();
+    }
+
+    /**
+     * Returns the minimum number of digits allowed in the fraction portion of a
+     * number.
+     *
+     * @see #setMinimumFractionDigits
+     */
+    @Override
+    public int getMinimumFractionDigits() {
+        return nf.getMinimumFractionDigits();
+    }
+
+    /**
+     * Returns the minimum number of digits allowed in the integer portion of a
+     * number.
+     *
+     * @see #setMinimumIntegerDigits
+     */
+    @Override
+    public int getMinimumIntegerDigits() {
+        return nf.getMinimumIntegerDigits();
+    }
+
+    /**
+     * Sets the maximum number of digits allowed in the fraction portion of a
+     * number. maximumFractionDigits must be >= minimumFractionDigits.  If the
+     * new value for maximumFractionDigits is less than the current value
+     * of minimumFractionDigits, then minimumFractionDigits will also be set to
+     * the new value.
+     *
+     * @param newValue the maximum number of fraction digits to be shown; if
+     *                 less than zero, then zero is used. The concrete subclass may enforce an
+     *                 upper limit to this value appropriate to the numeric type being formatted.
+     * @see #getMaximumFractionDigits
+     */
+    @Override
+    public void setMaximumFractionDigits(int newValue) {
+        nf.setMaximumFractionDigits(newValue);
+    }
+
+    /**
+     * Sets the minimum number of digits allowed in the integer portion of a
+     * number. minimumIntegerDigits must be <= maximumIntegerDigits.  If the
+     * new value for minimumIntegerDigits exceeds the current value
+     * of maximumIntegerDigits, then maximumIntegerDigits will also be set to
+     * the new value
+     *
+     * @param newValue the minimum number of integer digits to be shown; if
+     *                 less than zero, then zero is used. The concrete subclass may enforce an
+     *                 upper limit to this value appropriate to the numeric type being formatted.
+     * @see #getMinimumIntegerDigits
+     */
+    @Override
+    public void setMinimumIntegerDigits(int newValue) {
+        nf.setMinimumIntegerDigits(newValue);
+    }
+
+    /**
+     * Sets the minimum number of digits allowed in the fraction portion of a
+     * number. minimumFractionDigits must be <= maximumFractionDigits.  If the
+     * new value for minimumFractionDigits exceeds the current value
+     * of maximumFractionDigits, then maximumIntegerDigits will also be set to
+     * the new value
+     *
+     * @param newValue the minimum number of fraction digits to be shown; if
+     *                 less than zero, then zero is used. The concrete subclass may enforce an
+     *                 upper limit to this value appropriate to the numeric type being formatted.
+     * @see #getMinimumFractionDigits
+     */
+    @Override
+    public void setMinimumFractionDigits(int newValue) {
+        nf.setMinimumFractionDigits(newValue);
+    }
+
+    /**
+     * Sets the maximum number of digits allowed in the integer portion of a
+     * number. maximumIntegerDigits must be >= minimumIntegerDigits.  If the
+     * new value for maximumIntegerDigits is less than the current value
+     * of minimumIntegerDigits, then minimumIntegerDigits will also be set to
+     * the new value.
+     *
+     * @param newValue the maximum number of integer digits to be shown; if
+     *                 less than zero, then zero is used. The concrete subclass may enforce an
+     *                 upper limit to this value appropriate to the numeric type being formatted.
+     * @see #getMaximumIntegerDigits
+     */
+    @Override
+    public void setMaximumIntegerDigits(int newValue) {
+        nf.setMaximumIntegerDigits(newValue);
+    }
+
+    /**
+     * Specialization of format.
+     *
+     * @see java.text.Format#format
+     */
+     public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+        return nf.format(number * 100.0, toAppendTo, pos);
+    }
+
+    /**
+     * Specialization of format.
+     *
+     * @see java.text.Format#format
+     */
+     public StringBuffer format(long number, StringBuffer toAppendTo, FieldPosition pos) {
+        return nf.format(number * 100, toAppendTo, pos);
+    }
+
+    /**
+     * @see java.text.Format#parseObject
+     */
+     public Number parse(String source, ParsePosition parsePosition) {
+        return nf.parse(source, parsePosition).doubleValue() / 100.0;
+    }
+}


### PR DESCRIPTION
Adding a new Bare Percent label format option, e.g. "95" instead of "95%". Haven't tested this and no idea if it works. It might be better to implement the BarePercentFormat class as an extension of the PercentFormat class rather than an extension of NumberFormat, but whatever seems more sensible to you.